### PR TITLE
Fix/open wire output

### DIFF
--- a/amazonmq.cfndsl.rb
+++ b/amazonmq.cfndsl.rb
@@ -143,7 +143,7 @@ CloudFormation do
   }
   
   Output(:OpenWireEndpoints) { 
-    Value FnIf('IsMultiAZ', FnJoin(',', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617", ",", "ssl://", Ref(:Broker), "-2", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]), FnJoin(',', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]))
+    Value FnIf('IsMultiAZ', FnJoin('', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617", ",", "ssl://", Ref(:Broker), "-2", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]), FnJoin('', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]))
     Export FnSub("${EnvironmentName}-#{export}-openwire-endpoints")
   }
 

--- a/amazonmq.cfndsl.rb
+++ b/amazonmq.cfndsl.rb
@@ -143,8 +143,10 @@ CloudFormation do
   }
   
   Output(:OpenWireEndpoints) { 
-    Value FnJoin(',', FnGetAtt(:Broker, :OpenWireEndpoints))
-    Export FnSub("${EnvironmentName}-#{export}-openwire-endpoint-1")
+    Value FnIf('IsMultiAZ', FnJoin(',', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617", ",", "ssl://", Ref(:Broker), "-2", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]), FnJoin(',', ["ssl://", Ref(:Broker), "-1", ".mq.", Ref("AWS::Region"), ".amazonaws.com:61617"]))
+    Export FnSub("${EnvironmentName}-#{export}-openwire-endpoints")
   }
 
 end
+
+


### PR DESCRIPTION
This is a temporary fix for amazon issue related to `!GetAtt AmqBroker.OpenWireEndpoints` when using it in an output

for example:
```
Output(:OpenWireEndpoints) { 
    Value FnJoin(',', FnGetAtt(:Broker, :OpenWireEndpoints))
    Export FnSub("${EnvironmentName}-#{export}-openwire-endpoint-1")
  }
```